### PR TITLE
Switch from deprecated arma::is_finite(X) to X.is_finite()

### DIFF
--- a/src/utils_main.h
+++ b/src/utils_main.h
@@ -84,7 +84,7 @@ void clamp_log_data2(
     arma::vec& log_data2) {
   // -100 ~= log(4e-44)
   std::for_each(log_data2.begin(), log_data2.end(), [](double& value) { value = std::max(value, -100.0); });
-  if (not arma::is_finite(log_data2)) {
+  if (not log_data2.is_finite()) {
     Rcpp::Rcout << log_data2 << std::endl;
     ::Rf_error("Non-finite (+-inf or NaN) elements in the data set. This should not happen. It would help us if you could contact the maintainer with a reproducible example.");
   }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just a single statement. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.