### PR TITLE
replace ::R_CheckUserInterrupt with Rcpp::checkUserInterrupt

### DIFF
--- a/src/sampling_main.cc
+++ b/src/sampling_main.cc
@@ -155,7 +155,7 @@ List svsample_fast_cpp(
 
   for (int i = -burnin + 1; i < draws + 1; i++) {  // BEGIN main MCMC loop
     if (i % 20 == 0) {
-      ::R_CheckUserInterrupt();
+      Rcpp::checkUserInterrupt();
     }
 
     const bool parasave_round = (i - 1) % thinpara == thinpara - 1,  // is this a parameter saving round?
@@ -340,7 +340,7 @@ List svsample_general_cpp(
 
   for (int i = -burnin+1; i < draws+1; i++) {
     if (i % 20 == 0) {
-      ::R_CheckUserInterrupt();
+      Rcpp::checkUserInterrupt();
     }
 
     const bool parasave_round = (i - 1) % thinpara == thinpara - 1,  // is this a parameter saving round?


### PR DESCRIPTION
Quoting from https://www.rcpp.org/pdf/Rcpp-attributes.pdf:

> Note that R provides a C API for the same purpose
(R_CheckUserInterrupt) however this API is not safe to use in
C++ code as it uses longjmp to exit the current scope, bypassing any
C++ destructors on the stack. The Rcpp::checkUserInterrupt
function is provided as a safe alternative for C++ code.
